### PR TITLE
Change service method name to be consistent with Todoist integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft To Do integration for Home Assistant
 
-The integration brings your Microsoft To Do tasks into Home Assistant and also allows to create new tasks.
+The integration brings your Microsoft To Do tasks into Home Assistant and allows creating new tasks.
 
 ## Work in progress
 
@@ -38,14 +38,16 @@ calendar:
 
 Restart Home Assistant and finalize authorization through UI. There should be a new configuration request in notifications.
 
+*NOTE*: After successful auth please restart your Home Assistant again (it's known issue #10). 
+
 ## Services
 
-To create a task in Microsoft To Do you can call `microsoft_todo.ms_todo_new_task` service.
+To create a task in Microsoft To Do you can call `microsoft_todo.new_task` service.
 
 Simple example:
 
 ```yaml
-- service: microsoft_todo.ms_todo_new_task
+- service: microsoft_todo.new_task
   data:
     subject: "Test task"
     list_name: "Home Assistant"
@@ -63,7 +65,7 @@ automation:
       condition: template
       value_template: "{{ now().day == 1 }}"
     action:
-      - service: microsoft_todo.ms_todo_new_task
+      - service: microsoft_todo.new_task
         data_template:
           subject: "Pay utility bill for {{ now().replace(month=now().month - 1).strftime('%B') }}" # previous month name
           list_name: "Home Assistant"
@@ -72,13 +74,11 @@ automation:
           reminder_date_time: "{{ now().strftime('%Y-%m-%dT17:00:00') }}" # at 17:00 today
 ```
 
-*NOTE*: Service name might be changed in future [#5](https://github.com/black-roland/homeassistant-microsoft-todo/issues/5).
-
 ## Calendar sensors
 
 The integration creates a binary sensor for each to-do list with the tasks exposed as `all_tasks` attribute.
 
-Currently only `all_tasks` functionality is supported.
+Currently, only `all_tasks` functionality is supported.
 
 ```yaml
 automation:

--- a/custom_components/microsoft_todo/const.py
+++ b/custom_components/microsoft_todo/const.py
@@ -12,7 +12,7 @@ MS_TODO_AUTH_FILE = ".ms_todo_auth.json"
 ATTR_ACCESS_TOKEN = "access_token"
 ATTR_REFRESH_TOKEN = "refresh_token"
 
-SERVICE_NEW_TASK = "ms_todo_new_task"
+SERVICE_NEW_TASK = "new_task"
 
 SUBJECT = "subject"
 LIST_CONF = "list_conf"

--- a/info.md
+++ b/info.md
@@ -1,11 +1,17 @@
-# microsoft_todo.ms_todo_new_task
+# Microsoft To Do integration
 
-Example:
+The integration brings your Microsoft To Do tasks into Home Assistant and allows creating new tasks.
 
-```yaml
-- service: microsoft_todo.ms_todo_new_task
-  data:
-    subject: "Test task"
-```
+{% if installed %}
+## Breaking changes
 
-See README for details.
+Service name changed to `microsoft_todo.new_task`. Please update your automations.
+{% endif %}
+
+## Features
+
+- Ability to create new tasks in Microsoft To Do;
+- Custom due date, reminder date, and note;
+- Allows to expose your to-do lists as sensors and use in automations. 
+
+Please check [the repository](https://github.com/black-roland/homeassistant-microsoft-todo#readme) for configuration and usage instructions.


### PR DESCRIPTION
This PR updates service name to `microsoft_todo.new_task` to be consistent with the Todoist integration. Implements #5.